### PR TITLE
feat: Next.js rebuild + service/flow/contact pages

### DIFF
--- a/gas/contact-form.gs
+++ b/gas/contact-form.gs
@@ -1,0 +1,192 @@
+// ============================================================
+// Carriage お問い合わせフォーム — Google Apps Script
+// ============================================================
+//
+// 【セットアップ手順】
+// 1. Google Drive → 新規 → Google Apps Script
+// 2. このコードを貼り付け
+// 3. 下の定数を自分の環境に合わせて変更
+// 4. デプロイ → 新しいデプロイ → ウェブアプリ
+//    - 実行ユーザー: 自分
+//    - アクセス: 全員
+// 5. 表示されたURLをフロントの NEXT_PUBLIC_GAS_URL に設定
+// ============================================================
+
+/** 通知先メールアドレス */
+var NOTIFY_EMAIL = "info@carri-age.com";
+
+/** スプレッドシートID（空にすると自動作成） */
+var SPREADSHEET_ID = "";
+
+/** シート名 */
+var SHEET_NAME = "お問い合わせ";
+
+// ============================================================
+// POST ハンドラー
+// ============================================================
+function doPost(e) {
+  try {
+    var data = JSON.parse(e.postData.contents);
+
+    var company = data.company || "";
+    var name = data.name || "";
+    var email = data.email || "";
+    var category = data.category || "";
+    var message = data.message || "";
+    var timestamp = new Date();
+
+    // --- バリデーション ---
+    var errors = [];
+    if (!name) errors.push("お名前は必須です");
+    if (!email) errors.push("メールアドレスは必須です");
+    if (!message) errors.push("ご相談内容は必須です");
+
+    if (errors.length > 0) {
+      return buildResponse(400, { success: false, errors: errors });
+    }
+
+    // --- スプレッドシートに保存 ---
+    var sheet = getOrCreateSheet();
+    sheet.appendRow([
+      timestamp,
+      company,
+      name,
+      email,
+      category,
+      message,
+    ]);
+
+    // --- メール通知 ---
+    sendNotification(timestamp, company, name, email, category, message);
+
+    // --- 自動返信 ---
+    sendAutoReply(name, email, category, message);
+
+    return buildResponse(200, { success: true });
+  } catch (err) {
+    Logger.log("Error: " + err.toString());
+    return buildResponse(500, { success: false, errors: [err.toString()] });
+  }
+}
+
+// CORS プリフライト用
+function doGet() {
+  return buildResponse(200, { status: "ok" });
+}
+
+// ============================================================
+// スプレッドシート
+// ============================================================
+function getOrCreateSheet() {
+  var ss;
+
+  if (SPREADSHEET_ID) {
+    ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  } else {
+    // スクリプトに紐づいたスプレッドシートを使う or 新規作成
+    var files = DriveApp.getFilesByName("Carriage_お問い合わせ");
+    if (files.hasNext()) {
+      ss = SpreadsheetApp.open(files.next());
+    } else {
+      ss = SpreadsheetApp.create("Carriage_お問い合わせ");
+      var sheet = ss.getActiveSheet();
+      sheet.setName(SHEET_NAME);
+      sheet.appendRow([
+        "日時",
+        "会社名",
+        "お名前",
+        "メールアドレス",
+        "お問い合わせ種別",
+        "ご相談内容",
+      ]);
+      sheet.setFrozenRows(1);
+      // 作成されたシートIDをログに出力
+      Logger.log("Created spreadsheet: " + ss.getId());
+    }
+  }
+
+  var sheet = ss.getSheetByName(SHEET_NAME);
+  if (!sheet) {
+    sheet = ss.insertSheet(SHEET_NAME);
+    sheet.appendRow([
+      "日時",
+      "会社名",
+      "お名前",
+      "メールアドレス",
+      "お問い合わせ種別",
+      "ご相談内容",
+    ]);
+    sheet.setFrozenRows(1);
+  }
+
+  return sheet;
+}
+
+// ============================================================
+// メール通知（管理者向け）
+// ============================================================
+function sendNotification(timestamp, company, name, email, category, message) {
+  var subject = "【お問い合わせ】" + name + "様 - " + (category || "一般");
+
+  var body = [
+    "新しいお問い合わせがありました。",
+    "",
+    "━━━━━━━━━━━━━━━━━━━━",
+    "日時:           " + Utilities.formatDate(timestamp, "Asia/Tokyo", "yyyy/MM/dd HH:mm"),
+    "会社名:         " + (company || "（未入力）"),
+    "お名前:         " + name,
+    "メールアドレス: " + email,
+    "お問い合わせ種別: " + (category || "（未選択）"),
+    "━━━━━━━━━━━━━━━━━━━━",
+    "",
+    "【ご相談内容】",
+    message,
+    "",
+    "━━━━━━━━━━━━━━━━━━━━",
+  ].join("\n");
+
+  GmailApp.sendEmail(NOTIFY_EMAIL, subject, body);
+}
+
+// ============================================================
+// 自動返信（お客様向け）
+// ============================================================
+function sendAutoReply(name, email, category, message) {
+  var subject = "【キャリッジ株式会社】お問い合わせありがとうございます";
+
+  var body = [
+    name + " 様",
+    "",
+    "お問い合わせいただきありがとうございます。",
+    "以下の内容で承りました。",
+    "",
+    "━━━━━━━━━━━━━━━━━━━━",
+    "お問い合わせ種別: " + (category || "（未選択）"),
+    "",
+    "【ご相談内容】",
+    message,
+    "━━━━━━━━━━━━━━━━━━━━",
+    "",
+    "通常1営業日以内にご返信いたします。",
+    "しばらくお待ちくださいませ。",
+    "",
+    "---",
+    "キャリッジ株式会社",
+    "info@carri-age.com",
+    "https://www.carri-age.com",
+  ].join("\n");
+
+  GmailApp.sendEmail(email, subject, body, {
+    name: "キャリッジ株式会社",
+    replyTo: NOTIFY_EMAIL,
+  });
+}
+
+// ============================================================
+// CORS 対応レスポンス
+// ============================================================
+function buildResponse(statusCode, payload) {
+  var output = ContentService.createTextOutput(JSON.stringify(payload))
+    .setMimeType(ContentService.MimeType.JSON);
+  return output;
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { useState } from 'react';
+import { ScrollReveal } from '@/components/ui/ScrollReveal';
+
+const GAS_URL =
+  'https://script.google.com/macros/s/AKfycbw3lC3NkDzzT4BOFEijrV01m43bdDckXopaqkbnp5VievvF_fMCUEApI2ZIoZdjhWGj/exec';
+
+const categories = [
+  'MVP・プロトタイプ開発の相談',
+  'アプリ開発の相談',
+  'AI活用の相談',
+  '見積もり依頼',
+  'その他',
+];
+
+interface FormData {
+  company: string;
+  name: string;
+  email: string;
+  category: string;
+  message: string;
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error';
+
+export default function ContactPage() {
+  const [form, setForm] = useState<FormData>({
+    company: '',
+    name: '',
+    email: '',
+    category: '',
+    message: '',
+  });
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('submitting');
+    setErrorMessage('');
+
+    try {
+      const res = await fetch(GAS_URL, {
+        method: 'POST',
+        body: JSON.stringify(form),
+      });
+
+      const data = await res.json();
+
+      if (data.success) {
+        setStatus('success');
+        setForm({ company: '', name: '', email: '', category: '', message: '' });
+      } else {
+        setStatus('error');
+        setErrorMessage(data.errors?.join(', ') || '送信に失敗しました');
+      }
+    } catch {
+      setStatus('error');
+      setErrorMessage('通信エラーが発生しました。しばらく経ってからお試しください。');
+    }
+  };
+
+  return (
+    <div className="pt-24 pb-20">
+      <div className="mx-auto max-w-2xl px-4">
+        <ScrollReveal>
+          <div className="mb-12 text-center">
+            <p className="font-koho text-sm tracking-widest text-accent-purple">
+              Contact
+            </p>
+            <h1 className="mt-4 text-3xl font-bold md:text-5xl">
+              まずは壁打ちから。
+            </h1>
+            <p className="mx-auto mt-4 max-w-xl text-text-secondary">
+              「こんなの作れる？」「予算感を知りたい」「AIで何ができる？」
+              <br />
+              なんでもお気軽にご相談ください。通常1営業日以内にご返信いたします。
+            </p>
+          </div>
+        </ScrollReveal>
+
+        {status === 'success' ? (
+          <ScrollReveal>
+            <div className="rounded-2xl border border-accent-purple/50 bg-accent-purple/5 p-10 text-center">
+              <p className="text-4xl">✓</p>
+              <h2 className="mt-4 text-2xl font-bold">
+                送信ありがとうございます
+              </h2>
+              <p className="mt-3 text-text-secondary">
+                確認メールをお送りしました。
+                <br />
+                通常1営業日以内にご返信いたします。
+              </p>
+              <button
+                onClick={() => setStatus('idle')}
+                className="mt-8 text-sm text-accent-purple underline"
+              >
+                別のお問い合わせをする
+              </button>
+            </div>
+          </ScrollReveal>
+        ) : (
+          <ScrollReveal delay={0.2}>
+            <form
+              onSubmit={handleSubmit}
+              className="space-y-6 rounded-2xl border border-border bg-bg-card p-6 md:p-10"
+            >
+              {/* 会社名 */}
+              <div>
+                <label
+                  htmlFor="company"
+                  className="block text-sm font-bold text-text-primary"
+                >
+                  会社名
+                  <span className="ml-2 text-xs font-normal text-text-secondary">
+                    任意
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  id="company"
+                  name="company"
+                  value={form.company}
+                  onChange={handleChange}
+                  placeholder="キャリッジ株式会社"
+                  className="mt-2 w-full rounded-lg border border-border bg-bg-primary px-4 py-3 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent-purple focus:outline-none"
+                />
+              </div>
+
+              {/* お名前 */}
+              <div>
+                <label
+                  htmlFor="name"
+                  className="block text-sm font-bold text-text-primary"
+                >
+                  お名前
+                  <span className="ml-2 text-xs font-normal text-accent-purple">
+                    必須
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  value={form.name}
+                  onChange={handleChange}
+                  required
+                  placeholder="山田 太郎"
+                  className="mt-2 w-full rounded-lg border border-border bg-bg-primary px-4 py-3 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent-purple focus:outline-none"
+                />
+              </div>
+
+              {/* メールアドレス */}
+              <div>
+                <label
+                  htmlFor="email"
+                  className="block text-sm font-bold text-text-primary"
+                >
+                  メールアドレス
+                  <span className="ml-2 text-xs font-normal text-accent-purple">
+                    必須
+                  </span>
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  value={form.email}
+                  onChange={handleChange}
+                  required
+                  placeholder="you@example.com"
+                  className="mt-2 w-full rounded-lg border border-border bg-bg-primary px-4 py-3 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent-purple focus:outline-none"
+                />
+              </div>
+
+              {/* お問い合わせ種別 */}
+              <div>
+                <label
+                  htmlFor="category"
+                  className="block text-sm font-bold text-text-primary"
+                >
+                  お問い合わせ種別
+                  <span className="ml-2 text-xs font-normal text-text-secondary">
+                    任意
+                  </span>
+                </label>
+                <select
+                  id="category"
+                  name="category"
+                  value={form.category}
+                  onChange={handleChange}
+                  className="mt-2 w-full rounded-lg border border-border bg-bg-primary px-4 py-3 text-sm text-text-primary focus:border-accent-purple focus:outline-none"
+                >
+                  <option value="">選択してください</option>
+                  {categories.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {cat}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* ご相談内容 */}
+              <div>
+                <label
+                  htmlFor="message"
+                  className="block text-sm font-bold text-text-primary"
+                >
+                  ご相談内容
+                  <span className="ml-2 text-xs font-normal text-accent-purple">
+                    必須
+                  </span>
+                </label>
+                <textarea
+                  id="message"
+                  name="message"
+                  value={form.message}
+                  onChange={handleChange}
+                  required
+                  rows={6}
+                  placeholder="お気軽にご記入ください"
+                  className="mt-2 w-full resize-y rounded-lg border border-border bg-bg-primary px-4 py-3 text-sm text-text-primary placeholder:text-text-secondary/50 focus:border-accent-purple focus:outline-none"
+                />
+              </div>
+
+              {/* エラー */}
+              {status === 'error' && (
+                <p className="text-sm text-red-400">{errorMessage}</p>
+              )}
+
+              {/* 送信ボタン */}
+              <button
+                type="submit"
+                disabled={status === 'submitting'}
+                className="w-full rounded-full bg-accent-purple px-8 py-4 text-base font-bold text-white shadow-lg shadow-accent-purple/25 transition-all duration-300 hover:bg-accent-purple/80 hover:shadow-accent-purple/40 disabled:opacity-50"
+              >
+                {status === 'submitting' ? '送信中...' : '送信する →'}
+              </button>
+            </form>
+          </ScrollReveal>
+        )}
+
+        <ScrollReveal delay={0.3}>
+          <p className="mt-8 text-center text-sm text-text-secondary">
+            フォーム以外でのご連絡は{' '}
+            <a
+              href="mailto:info@carri-age.com"
+              className="text-accent-purple underline"
+            >
+              info@carri-age.com
+            </a>{' '}
+            までお気軽にどうぞ。
+          </p>
+        </ScrollReveal>
+      </div>
+    </div>
+  );
+}

--- a/src/app/flow/page.tsx
+++ b/src/app/flow/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { SectionHeading } from '@/components/ui/SectionHeading';
+import { ScrollReveal } from '@/components/ui/ScrollReveal';
+import { Button } from '@/components/ui/Button';
+
+const steps = [
+  {
+    number: '01',
+    title: 'ヒアリング・壁打ち',
+    subtitle: '無料',
+    description:
+      '「こんなの作れる？」からでOK。アイデア段階でも、ざっくりした構想でも大丈夫です。技術的な実現可能性やコスト感をお伝えします。',
+    icon: '💬',
+  },
+  {
+    number: '02',
+    title: '要件定義・見積もり',
+    subtitle: '1〜2週間',
+    description:
+      'ヒアリング内容をもとに、機能一覧・画面構成・技術選定をまとめます。明確な見積もりと開発スケジュールをご提案。',
+    icon: '📋',
+  },
+  {
+    number: '03',
+    title: 'デザイン',
+    subtitle: '1〜2週間',
+    description:
+      'Figmaでワイヤーフレーム → UIデザインを作成。実際の画面イメージを見ながらフィードバックいただけます。',
+    icon: '🎨',
+  },
+  {
+    number: '04',
+    title: '開発（AI×オフショア）',
+    subtitle: '1〜3ヶ月',
+    description:
+      'AIを活用した高速開発 + オフショアチームのリソースで、品質を保ちながらスピーディーに開発。週次で進捗を共有します。',
+    icon: '⚡',
+  },
+  {
+    number: '05',
+    title: 'テスト・QA',
+    subtitle: '1〜2週間',
+    description:
+      '機能テスト、UIテスト、パフォーマンステストを実施。バグの修正とブラッシュアップを行います。',
+    icon: '🔍',
+  },
+  {
+    number: '06',
+    title: 'リリース・運用サポート',
+    subtitle: '継続',
+    description:
+      '本番環境へのデプロイ、ストア申請（アプリの場合）をサポート。リリース後の改善・運用もお任せください。',
+    icon: '🚀',
+  },
+];
+
+export default function FlowPage() {
+  return (
+    <div className="pt-24 pb-20">
+      <div className="mx-auto max-w-4xl px-4">
+        <ScrollReveal>
+          <SectionHeading en="Flow" ja="開発の流れ" />
+        </ScrollReveal>
+
+        <div className="relative">
+          {/* Vertical line */}
+          <div className="absolute left-6 top-0 hidden h-full w-px bg-border md:block" />
+
+          <div className="space-y-12">
+            {steps.map((step, i) => (
+              <ScrollReveal key={step.number} delay={i * 0.1}>
+                <div className="relative flex gap-6 md:gap-8">
+                  {/* Icon circle */}
+                  <div className="relative z-10 flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-accent-purple bg-bg-primary text-xl">
+                    {step.icon}
+                  </div>
+
+                  {/* Content */}
+                  <div className="flex-1 rounded-2xl border border-border bg-bg-card p-6">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <span className="font-koho text-sm font-bold text-accent-purple">
+                        STEP {step.number}
+                      </span>
+                      <span className="rounded-full bg-accent-yellow/10 px-3 py-0.5 text-xs font-bold text-accent-yellow">
+                        {step.subtitle}
+                      </span>
+                    </div>
+                    <h3 className="mt-2 text-xl font-bold">{step.title}</h3>
+                    <p className="mt-2 text-sm leading-relaxed text-text-secondary">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              </ScrollReveal>
+            ))}
+          </div>
+        </div>
+
+        <ScrollReveal delay={0.3}>
+          <div className="mt-16 text-center">
+            <h3 className="text-2xl font-bold">
+              まずはStep 01から。
+            </h3>
+            <p className="mt-4 text-text-secondary">
+              ヒアリング・壁打ちは無料です。お気軽にご相談ください。
+            </p>
+            <div className="mt-8">
+              <Button href="/contact" size="lg">
+                無料で相談する →
+              </Button>
+            </div>
+          </div>
+        </ScrollReveal>
+      </div>
+    </div>
+  );
+}

--- a/src/app/service/page.tsx
+++ b/src/app/service/page.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { SectionHeading } from '@/components/ui/SectionHeading';
+import { ScrollReveal } from '@/components/ui/ScrollReveal';
+import { Button } from '@/components/ui/Button';
+
+const plans = [
+  {
+    name: 'Light',
+    price: '150万円〜',
+    description: 'MVP・プロトタイプ開発',
+    features: [
+      'LP / シンプルなWebアプリ',
+      'AI機能の組み込み',
+      '開発期間: 1〜2ヶ月',
+      'デザイン込み',
+    ],
+    details: {
+      includes: [
+        'ヒアリング・要件定義',
+        'UI/UXデザイン（最大5画面）',
+        'フロントエンド開発',
+        'ベーシックなAPI連携',
+        'レスポンシブ対応',
+        'リリースサポート',
+      ],
+      useCases: [
+        'スタートアップのMVP検証',
+        'サービスのランディングページ',
+        '社内ツールのプロトタイプ',
+        'AIチャットボットの組み込み',
+      ],
+    },
+    highlighted: false,
+  },
+  {
+    name: 'Standard',
+    price: '300万円〜',
+    description: '本格的なプロダクト開発',
+    features: [
+      'Webアプリ / モバイルアプリ',
+      'ユーザー認証・管理画面',
+      '開発期間: 2〜4ヶ月',
+      'AI機能フル活用',
+    ],
+    details: {
+      includes: [
+        'ヒアリング・要件定義',
+        'UI/UXデザイン（画面数制限なし）',
+        'フロントエンド + バックエンド開発',
+        'ユーザー認証・権限管理',
+        '管理画面',
+        'AI機能の設計・実装',
+        'テスト・QA',
+        'リリース + 1ヶ月サポート',
+      ],
+      useCases: [
+        'BtoB SaaSプロダクト',
+        'モバイルアプリ（iOS/Android）',
+        'AI搭載の業務支援ツール',
+        'マーケットプレイス・ECサイト',
+      ],
+    },
+    highlighted: true,
+  },
+  {
+    name: 'Enterprise',
+    price: '要相談',
+    description: '大規模システム開発',
+    features: [
+      '基幹システム連携',
+      'スケーラブルなアーキテクチャ',
+      '開発期間: 4ヶ月〜',
+      '運用・保守サポート',
+    ],
+    details: {
+      includes: [
+        '詳細なヒアリング・業務分析',
+        'アーキテクチャ設計',
+        'フルスタック開発',
+        '外部システム連携（API・DB）',
+        'セキュリティ設計・監査対応',
+        '負荷テスト・パフォーマンス最適化',
+        '運用・保守サポート（長期）',
+        'チーム体制のスケールアップ',
+      ],
+      useCases: [
+        '基幹システムのモダナイズ',
+        '大規模AIプラットフォーム',
+        '複数サービス連携のシステム構築',
+        '高セキュリティ要件のヘルスケア・金融系',
+      ],
+    },
+    highlighted: false,
+  },
+];
+
+export default function ServicePage() {
+  return (
+    <div className="pt-24 pb-20">
+      <div className="mx-auto max-w-6xl px-4">
+        <ScrollReveal>
+          <SectionHeading en="Service" ja="150万ボッキリMVP開発" />
+        </ScrollReveal>
+
+        <div className="grid gap-8 md:grid-cols-3">
+          {plans.map((plan, i) => (
+            <ScrollReveal key={plan.name} delay={i * 0.15}>
+              <div
+                className={`relative rounded-2xl border p-8 transition-colors ${
+                  plan.highlighted
+                    ? 'border-accent-purple bg-accent-purple/5'
+                    : 'border-border bg-bg-card hover:border-accent-purple/50'
+                }`}
+              >
+                {plan.highlighted && (
+                  <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-accent-purple px-4 py-1 text-xs font-bold text-white">
+                    POPULAR
+                  </span>
+                )}
+                <h3 className="font-koho text-2xl font-bold">{plan.name}</h3>
+                <p className="mt-1 text-sm text-text-secondary">
+                  {plan.description}
+                </p>
+                <p className="mt-4 text-3xl font-bold text-accent-yellow">
+                  {plan.price}
+                </p>
+                <ul className="mt-6 space-y-3">
+                  {plan.features.map((feature) => (
+                    <li
+                      key={feature}
+                      className="flex items-start gap-2 text-sm text-text-secondary"
+                    >
+                      <span className="mt-0.5 text-accent-purple">✓</span>
+                      {feature}
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="mt-8 border-t border-border pt-6">
+                  <h4 className="text-sm font-bold text-text-primary">
+                    含まれるもの
+                  </h4>
+                  <ul className="mt-3 space-y-2">
+                    {plan.details.includes.map((item) => (
+                      <li
+                        key={item}
+                        className="flex items-start gap-2 text-sm text-text-secondary"
+                      >
+                        <span className="mt-0.5 text-accent-yellow">-</span>
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="mt-6 border-t border-border pt-6">
+                  <h4 className="text-sm font-bold text-text-primary">
+                    想定ユースケース
+                  </h4>
+                  <ul className="mt-3 space-y-2">
+                    {plan.details.useCases.map((useCase) => (
+                      <li
+                        key={useCase}
+                        className="flex items-start gap-2 text-sm text-text-secondary"
+                      >
+                        <span className="mt-0.5 text-accent-purple">●</span>
+                        {useCase}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="mt-8">
+                  <Button
+                    href="/contact"
+                    variant={plan.highlighted ? 'primary' : 'secondary'}
+                    className="w-full"
+                  >
+                    相談する
+                  </Button>
+                </div>
+              </div>
+            </ScrollReveal>
+          ))}
+        </div>
+
+        <ScrollReveal delay={0.3}>
+          <div className="mt-16 text-center">
+            <p className="text-text-secondary">
+              どのプランが最適かわからない場合も、お気軽にご相談ください。
+            </p>
+            <div className="mt-6 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+              <Button href="/flow" variant="secondary">
+                開発の流れを見る →
+              </Button>
+              <Button href="/contact">
+                無料で相談する →
+              </Button>
+            </div>
+          </div>
+        </ScrollReveal>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
 
@@ -8,6 +9,7 @@ const navLinks = [
   { href: '#philosophy', label: 'Philosophy' },
   { href: '#service', label: 'Service' },
   { href: '#works', label: 'Works' },
+  { href: '/flow', label: 'Flow', isPage: true },
   { href: '#team', label: 'Team' },
   { href: '#company', label: 'Company' },
   { href: '#contact', label: 'Contact' },
@@ -15,20 +17,31 @@ const navLinks = [
 
 export function Header() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isTopPage, setIsTopPage] = useState(true);
+
+  useEffect(() => {
+    setIsTopPage(window.location.pathname === '/');
+  }, []);
+
+  const getHref = (link: (typeof navLinks)[number]) => {
+    if (link.isPage) return link.href;
+    if (isTopPage) return link.href;
+    return `/${link.href}`;
+  };
 
   return (
     <header className="fixed top-0 z-50 w-full border-b border-border bg-bg-primary/80 backdrop-blur-md">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
-        <a href="#" className="font-koho text-xl font-bold text-text-primary">
+        <Link href="/" className="font-koho text-xl font-bold text-text-primary">
           Carriage
-        </a>
+        </Link>
 
         {/* Desktop nav */}
         <nav className="hidden gap-8 md:flex">
           {navLinks.map((link) => (
             <a
               key={link.href}
-              href={link.href}
+              href={getHref(link)}
               className="font-koho text-sm text-text-secondary transition-colors hover:text-accent-purple"
             >
               {link.label}
@@ -77,7 +90,7 @@ export function Header() {
               {navLinks.map((link) => (
                 <a
                   key={link.href}
-                  href={link.href}
+                  href={getHref(link)}
                   onClick={() => setIsOpen(false)}
                   className="font-koho text-lg text-text-secondary transition-colors hover:text-accent-purple"
                 >

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -24,10 +24,10 @@ export function ContactSection() {
         <ScrollReveal delay={0.2}>
           <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
             <Button
-              href="mailto:info@carri-age.com"
+              href="/contact"
               size="lg"
             >
-              メールで相談する →
+              相談フォームへ →
             </Button>
           </div>
         </ScrollReveal>

--- a/src/components/sections/PhilosophySection.tsx
+++ b/src/components/sections/PhilosophySection.tsx
@@ -34,8 +34,8 @@ export function PhilosophySection() {
 
         <div className="grid gap-8 md:grid-cols-3">
           {pillars.map((pillar, i) => (
-            <ScrollReveal key={pillar.title} delay={i * 0.15}>
-              <div className="rounded-2xl border border-border bg-bg-card p-8 transition-colors hover:border-accent-purple/50">
+            <ScrollReveal key={pillar.title} delay={i * 0.15} className="h-full">
+              <div className="h-full rounded-2xl border border-border bg-bg-card p-8 transition-colors hover:border-accent-purple/50">
                 <div className="text-4xl">{pillar.icon}</div>
                 <h3 className="mt-4 text-xl font-bold">{pillar.title}</h3>
                 <p className="mt-3 leading-relaxed text-text-secondary">

--- a/src/components/sections/ServiceSection.tsx
+++ b/src/components/sections/ServiceSection.tsx
@@ -97,6 +97,14 @@ export function ServiceSection() {
             </ScrollReveal>
           ))}
         </div>
+
+        <ScrollReveal delay={0.3}>
+          <div className="mt-10 text-center">
+            <Button href="/service" variant="secondary">
+              詳しく見る →
+            </Button>
+          </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/src/components/sections/TechStackSection.tsx
+++ b/src/components/sections/TechStackSection.tsx
@@ -12,20 +12,20 @@ export function TechStackSection() {
           <SectionHeading en="Tech Stack" ja="使ってる技術" />
         </ScrollReveal>
 
-        <div className="space-y-8">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           {categories.map((category, ci) => {
             const items = techStack.filter((t) => t.category === category);
             return (
-              <ScrollReveal key={category} delay={ci * 0.1}>
-                <div>
+              <ScrollReveal key={category} delay={ci * 0.05}>
+                <div className="rounded-2xl border border-border bg-bg-card p-6">
                   <h3 className="font-koho mb-3 text-sm font-semibold tracking-wider text-accent-purple">
                     {category}
                   </h3>
-                  <div className="flex flex-wrap gap-3">
+                  <div className="flex flex-wrap gap-2">
                     {items.map((item) => (
                       <span
                         key={item.name}
-                        className="rounded-lg border border-border bg-bg-card px-4 py-2 text-sm text-text-primary transition-colors hover:border-accent-purple/50"
+                        className="rounded-lg border border-border bg-bg-primary px-3 py-1.5 text-sm text-text-primary transition-colors hover:border-accent-purple/50"
                       >
                         {item.name}
                       </span>

--- a/src/data/works.ts
+++ b/src/data/works.ts
@@ -10,36 +10,43 @@ export const works: Work[] = [
   {
     title: 'ヨミツギ',
     description:
-      'AIが物語の「続き」を生成する、インタラクティブ読書体験アプリ。読者の選択で物語が分岐する新しい読書のカタチ。',
-    tags: ['Next.js', 'OpenAI', 'Supabase'],
+      '本のマーケットプレイスアプリ。ユーザー間で本を売買できるプラットフォーム。Stripe決済連携で安全な取引を実現。',
+    tags: ['Next.js', 'Expo', 'Supabase', 'Stripe'],
     type: 'own',
   },
   {
     title: 'ツンドク',
     description:
-      'AIが積読を解消する読書管理アプリ。本の要約・読書プラン生成で、積読ゼロを目指す。',
-    tags: ['React Native', 'Claude API', 'Firebase'],
+      '読書管理・積読解消アプリ。読書記録の管理、積読リストの可視化で読書習慣をサポート。',
+    tags: ['Expo', 'Supabase', 'React Native'],
     type: 'own',
-  },
-  {
-    title: 'AURORA',
-    description:
-      'クリエイター向けポートフォリオ自動生成SaaS。SNSやGitHubの情報からAIがポートフォリオを自動作成。',
-    tags: ['Next.js', 'TypeScript', 'OpenAI'],
-    type: 'client',
   },
   {
     title: 'Practas',
     description:
-      '実践型プログラミング学習プラットフォーム。AIメンターがリアルタイムでコードレビュー・アドバイス。',
-    tags: ['React', 'Python', 'AWS'],
+      '実践型トレーニングアプリ。トレーニングメニューの管理・記録をアプリで完結。React管理画面でコンテンツ管理。',
+    tags: ['Flutter', 'Firebase', 'React'],
     type: 'client',
   },
   {
-    title: 'Strasj',
+    title: '語学学習プラットフォーム',
     description:
-      'AI搭載の戦略立案ツール。市場分析・競合調査をAIが自動化し、意思決定をサポート。',
-    tags: ['Next.js', 'LangChain', 'GCP'],
+      'AI音声認識を活用した語学学習プラットフォーム。Google Cloud Speech APIで発音チェック、LINE連携で学習リマインド。',
+    tags: ['Next.js', 'Supabase', 'Google Cloud', 'LINE API'],
+    type: 'client',
+  },
+  {
+    title: 'リハビリAIシステム',
+    description:
+      'AI搭載のリハビリ支援システム。患者データの分析・リハビリプランの自動提案で医療現場をサポート。',
+    tags: ['React', 'FastAPI', 'PostgreSQL', 'Azure', 'Dify'],
+    type: 'client',
+  },
+  {
+    title: 'Voice2SOAP',
+    description:
+      '音声からSOAPカルテを自動生成する医療記録支援システム。MFA認証でセキュアな環境を提供。',
+    tags: ['React', 'Firebase', 'MFA認証'],
     type: 'client',
   },
 ];


### PR DESCRIPTION
## Summary
- Next.js 15 + Tailwind CSS v4 でコーポレートサイトをリビルド
- `/service` `/flow` `/contact` ページを新規追加
- Works データを実プロジェクトに更新
- TechStack セクションを2カラムグリッドに改善
- GAS連携のお問い合わせフォームを実装

## Test plan
- [ ] `npm run build` が成功すること
- [ ] 各ページ (`/service`, `/flow`, `/contact`) にナビゲーションできること
- [ ] お問い合わせフォーム送信が GAS に届くこと
- [ ] レスポンシブ表示の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)